### PR TITLE
cargo-auditable uses project README

### DIFF
--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-secure-code/cargo-auditable"
 description = "Make production Rust binaries auditable"
 categories = ["cargo-plugins", "encoding"]
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
solves the readme item of https://github.com/rust-secure-code/cargo-auditable/issues/49

Example: https://github.com/rust-native-ui/libui-rs/blob/0.3.0/iui/Cargo.toml#L19 and  https://crates.io/crates/iui