### PR TITLE
Replace --only-section with --dump-section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It is not yet stabilized, so we do not have extensive docs or a JSON schema. How
 
 Yes. The data format is designed for interoperability with alternative implementations. You can also use pre-existing platform-specific tools or libraries for data extraction. E.g. on Linux:
 ```bash
-objcopy -O binary --only-section=.dep-v0 target/release/hello-auditable /dev/stdout | pigz -zd -
+objcopy --dump-section .dep-v0=/dev/stdout target/release/hello-auditable | pigz -zd -
 ```
 However, [don't run legacy tools on untrusted files](https://lcamtuf.blogspot.com/2014/10/psa-dont-run-strings-on-untrusted-files.html). Use the `auditable-extract` crate or the `rust-audit-info` command-line tool if possible - they are written in 100% safe Rust, so they will not have such vulnerabilities.
 


### PR DESCRIPTION
I tried the following command in README, but it produced empty.

```
$ objcopy -O binary --only-section=.dep-v0 target/release/hello-auditable /dev/stdout
```

Looks like `--only-section` with `-O binary` skips sections that are flagged neither loaded ("load") nor allocated ("alloc").

https://stackoverflow.com/questions/3925075/how-to-extract-only-the-raw-contents-of-an-elf-section

If I understand correctly, `.dep-v0` doesn't have any flag.

```
  [29] .dep-v0           PROGBITS         0000000000000000  001618d4
       0000000000000360  0000000000000000           0     0     1
```

`--dump-section` worked for me. Please correct me if I'm missing something.