### PR TITLE
Add a JSON schema for the data format

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ It is also interoperable with existing tooling that consumes Cargo.lock via the 
 
 ### What is the data format, exactly?
 
-It is not yet stabilized, so we do not have extensive docs or a JSON schema. However, [these Rust data structures](https://docs.rs/auditable-serde/latest/auditable_serde/struct.Package.html) map to JSON one-to-one and are extensively commented. The JSON is Zlib-compressed and placed in a linker section named `.dep-v0`.
+The data format is described by the JSON schema [here](cargo-auditable.schema.json).
+The JSON is Zlib-compressed and placed in a linker section named `.dep-v0`.
 
 ### Can I read this data using a tool written in a different language?
 

--- a/auditable-serde/Cargo.toml
+++ b/auditable-serde/Cargo.toml
@@ -15,6 +15,7 @@ all-features = true
 default = []
 from_metadata = ["cargo_metadata"]
 toml = ["cargo-lock"]
+schema = ["schemars"]
 
 [dependencies]
 serde = { version = "1", features = ["serde_derive"] }
@@ -23,6 +24,7 @@ semver = { version = "1.0", features = ["serde"] }
 cargo_metadata = { version = "0.15", optional = true }
 cargo-lock = { version = "8.0.2", default-features = false, optional = true }
 topological-sort = "0.2.2"
+schemars = {version = "0.8.10", optional = true }
 
 [[example]]
 name = "json-to-toml"

--- a/auditable-serde/src/lib.rs
+++ b/auditable-serde/src/lib.rs
@@ -469,10 +469,8 @@ mod tests {
         let mut metadata = *schema.schema.metadata.clone().unwrap();
 
         let title = "cargo-auditable schema".to_string();
-        let id = "https://raw.githubusercontent.com/rust-secure-code/cargo-auditable/master/cargo-auditable.schema.json"
-            .to_string();
         metadata.title = Some(title);
-        metadata.id = Some(id);
+        metadata.id = Some("https://rustsec.org/schemas/cargo-auditable.json".to_string());
         metadata.examples = [].to_vec();
         metadata.description = Some(
             "Describes the `VersionInfo` JSON data structure that cargo-auditable embeds into Rust binaries."

--- a/cargo-auditable.schema.json
+++ b/cargo-auditable.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/rust-secure-code/cargo-auditable/master/cargo-auditable.schema.json",
+    "$id": "https://rustsec.org/schemas/cargo-auditable.json",
     "title": "cargo-auditable schema",
     "description": "Describes the `VersionInfo` JSON data structure that cargo-auditable embeds into Rust binaries.",
     "type": "object",

--- a/cargo-auditable.schema.json
+++ b/cargo-auditable.schema.json
@@ -1,0 +1,102 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/rust-secure-code/cargo-auditable/master/cargo-auditable.schema.json",
+    "title": "cargo-auditable schema",
+    "description": "Describes the `VersionInfo` JSON data structure that cargo-auditable embeds into Rust binaries.",
+    "type": "object",
+    "required": [
+        "packages"
+    ],
+    "properties": {
+        "packages": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Package"
+            }
+        }
+    },
+    "definitions": {
+        "DependencyKind": {
+            "description": "The values are ordered from weakest to strongest so that casting to integer would make sense",
+            "type": "string",
+            "enum": [
+                "build",
+                "runtime"
+            ]
+        },
+        "Package": {
+            "description": "A single package in the dependency tree",
+            "type": "object",
+            "required": [
+                "name",
+                "source",
+                "version"
+            ],
+            "properties": {
+                "dependencies": {
+                    "description": "Packages are stored in an ordered array both in the `VersionInfo` struct and in JSON. Here we refer to each package by its index in the array. May be omitted if the list is empty.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "uint",
+                        "minimum": 0.0
+                    }
+                },
+                "kind": {
+                    "description": "\"build\" or \"runtime\". May be omitted if set to \"runtime\". If it's both a build and a runtime dependency, \"runtime\" is recorded.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/DependencyKind"
+                        }
+                    ]
+                },
+                "name": {
+                    "description": "Crate name specified in the `name` field in Cargo.toml file. Examples: \"libc\", \"rand\"",
+                    "type": "string"
+                },
+                "root": {
+                    "description": "Whether this is the root package in the dependency tree. There should only be one root package. May be omitted if set to `false`.",
+                    "type": "boolean"
+                },
+                "source": {
+                    "description": "Currently \"git\", \"local\", \"crates.io\" or \"registry\". Designed to be extensible with other revision control systems, etc.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Source"
+                        }
+                    ]
+                },
+                "version": {
+                    "description": "The package's version in the [semantic version](https://semver.org) format.",
+                    "type": "string"
+                }
+            }
+        },
+        "Source": {
+            "description": "Serializes to \"git\", \"local\", \"crates.io\" or \"registry\". Designed to be extensible with other revision control systems, etc.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "enum": [
+                        "CratesIo",
+                        "Git",
+                        "Local",
+                        "Registry"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "Other"
+                    ],
+                    "properties": {
+                        "Other": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-secure-code/cargo-auditable/issues/72

Uses [schemars](https://github.com/GREsau/schemars) to derive the JSON schema, and adds a test to ensure the checked in schema is up to date with the code.