### PR TITLE
Pass CLI arguments such as `--offline` to `cargo metadata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "miniz_oxide 0.5.4",
  "object",
  "pico-args",
+ "serde",
  "serde_json",
 ]
 
@@ -318,18 +319,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -18,6 +18,7 @@ miniz_oxide = {version = "0.5.0"}
 serde_json = "1.0.57"
 cargo_metadata = "0.15"
 pico-args = "0.5"
+serde = "1.0.147"
 
 [dev-dependencies]
 cargo_metadata = "0.15"

--- a/cargo-auditable/src/cargo_arguments.rs
+++ b/cargo-auditable/src/cargo_arguments.rs
@@ -1,0 +1,45 @@
+use std::ffi::OsString;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+/// Includes only the cargo arguments we care about
+pub struct CargoArgs {
+    pub offline: bool,
+    pub locked: bool,
+    pub frozen: bool,
+    pub config: Vec<String>,
+}
+
+impl CargoArgs {
+    /// Extracts Cargo flags from the arguments to the current process
+    pub fn from_args() -> CargoArgs {
+        // we .skip(3) to get over `cargo auditable build` and to the start of the flags
+        let raw_args: Vec<OsString> = std::env::args_os().skip(3).collect();
+        Self::from_args_vec(raw_args)
+    }
+
+    /// Split into its own function for unit testing
+    fn from_args_vec(mut raw_args: Vec<OsString>) -> CargoArgs {
+        // if there is a -- in the invocation somewhere, only parse up to it
+        if let Some(position) = raw_args.iter().position(|s| s == "--") {
+            raw_args.truncate(position);
+        }
+        let mut parser = pico_args::Arguments::from_vec(raw_args);
+
+        CargoArgs {
+            config: parser.values_from_str("--config").unwrap(),
+            offline: parser.contains("--offline"),
+            locked: parser.contains("--locked"),
+            frozen: parser.contains("--frozen"),
+        }
+    }
+
+    /// Recovers `SerializedCargoArgs` from an environment variable (if it was exported earlier)
+    pub fn from_env() -> Result<Self, std::env::VarError> {
+        let json_args = std::env::var("CARGO_AUDITABLE_ORIG_ARGS")?;
+        // We unwrap here because we've serialized these args ourselves and they should roundtrip cleanly.
+        // Deserialization would only fail if someone tampered with them in transit.
+        Ok(serde_json::from_str(&json_args).unwrap())
+    }
+}

--- a/cargo-auditable/src/cargo_arguments.rs
+++ b/cargo-auditable/src/cargo_arguments.rs
@@ -43,3 +43,28 @@ impl CargoArgs {
         Ok(serde_json::from_str(&json_args).unwrap())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_parsing() {
+        let input = ["cargo", "auditable", "build", "--locked", "--config", "net.git-fetch-with-cli=true", "--offline"];
+        let raw_args = input.iter().map(|s| OsString::from(s)).collect();
+        let args = CargoArgs::from_args_vec(raw_args);
+        assert_eq!(args.locked, true);
+        assert_eq!(args.offline, true);
+        assert_eq!(args.frozen, false);
+        assert_eq!(args.config, vec!["net.git-fetch-with-cli=true"]);
+    }
+
+    #[test]
+    fn test_double_dash_to_ignore_args() {
+        let input = ["cargo", "auditable", "run", "--release", "--config", "net.git-fetch-with-cli=true", "--", "--offline"];
+        let raw_args = input.iter().map(|s| OsString::from(s)).collect();
+        let args = CargoArgs::from_args_vec(raw_args);
+        assert_eq!(args.offline, false);
+        assert_eq!(args.config, vec!["net.git-fetch-with-cli=true"]);
+    }
+}

--- a/cargo-auditable/src/cargo_arguments.rs
+++ b/cargo-auditable/src/cargo_arguments.rs
@@ -50,7 +50,15 @@ mod tests {
 
     #[test]
     fn test_basic_parsing() {
-        let input = ["cargo", "auditable", "build", "--locked", "--config", "net.git-fetch-with-cli=true", "--offline"];
+        let input = [
+            "cargo",
+            "auditable",
+            "build",
+            "--locked",
+            "--config",
+            "net.git-fetch-with-cli=true",
+            "--offline",
+        ];
         let raw_args = input.iter().map(|s| OsString::from(s)).collect();
         let args = CargoArgs::from_args_vec(raw_args);
         assert_eq!(args.locked, true);
@@ -61,7 +69,16 @@ mod tests {
 
     #[test]
     fn test_double_dash_to_ignore_args() {
-        let input = ["cargo", "auditable", "run", "--release", "--config", "net.git-fetch-with-cli=true", "--", "--offline"];
+        let input = [
+            "cargo",
+            "auditable",
+            "run",
+            "--release",
+            "--config",
+            "net.git-fetch-with-cli=true",
+            "--",
+            "--offline",
+        ];
         let raw_args = input.iter().map(|s| OsString::from(s)).collect();
         let args = CargoArgs::from_args_vec(raw_args);
         assert_eq!(args.offline, false);

--- a/cargo-auditable/src/cargo_arguments.rs
+++ b/cargo-auditable/src/cargo_arguments.rs
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_basic_parsing() {
+    fn basic_parsing() {
         let input = [
             "cargo",
             "auditable",
@@ -68,7 +68,30 @@ mod tests {
     }
 
     #[test]
-    fn test_double_dash_to_ignore_args() {
+    fn with_unrelated_flags() {
+        let input = [
+            "cargo",
+            "auditable",
+            "build",
+            "--locked",
+            "--target",
+            "x86_64-unknown-linux-gnu",
+            "--release",
+            "--config",
+            "net.git-fetch-with-cli=true",
+            "--offline",
+            "--ignore-rust-version",
+        ];
+        let raw_args = input.iter().map(|s| OsString::from(s)).collect();
+        let args = CargoArgs::from_args_vec(raw_args);
+        assert_eq!(args.locked, true);
+        assert_eq!(args.offline, true);
+        assert_eq!(args.frozen, false);
+        assert_eq!(args.config, vec!["net.git-fetch-with-cli=true"]);
+    }
+
+    #[test]
+    fn double_dash_to_ignore_args() {
         let input = [
             "cargo",
             "auditable",

--- a/cargo-auditable/src/cargo_auditable.rs
+++ b/cargo-auditable/src/cargo_auditable.rs
@@ -1,4 +1,4 @@
-use crate::cargo_arguments::SerializedCargoArgs;
+use crate::cargo_arguments::CargoArgs;
 use std::{env, process::Command};
 
 pub fn main() {
@@ -19,8 +19,10 @@ pub fn main() {
     // We're interested in flags like `--offline` and `--config` which have to be passed to `cargo metadata` later.
     // The shell has already split them for us and we don't want to mangle them, but we need to round-trip them
     // through a string. Since we already depend on `serde-json` and it does the job, use JSON.
-    // This doesn't support non-UTF8 paths, but `cargo_metadata` crate doesn't support them either, so...
-    let args = SerializedCargoArgs::from_args();
+    // This doesn't support non-UTF8 arguments, but `cargo_metadata` crate doesn't support them either,
+    // so this is not an issue right now.
+    // If it ever becomes one, we could use the `serde-bytes-repr` crate for a clean round-trip.
+    let args = CargoArgs::from_args();
     let args_in_json = serde_json::to_string(&args).unwrap();
     command.env("CARGO_AUDITABLE_ORIG_ARGS", args_in_json);
 

--- a/cargo-auditable/src/cargo_auditable.rs
+++ b/cargo-auditable/src/cargo_auditable.rs
@@ -1,3 +1,4 @@
+use crate::cargo_arguments::SerializedCargoArgs;
 use std::{env, process::Command};
 
 pub fn main() {
@@ -13,6 +14,16 @@ pub fn main() {
     // This would matter if the binary was made setuid, but it isn't, so this should be fine.
     let path_to_this_binary = std::env::current_exe().unwrap();
     command.env("RUSTC_WORKSPACE_WRAPPER", path_to_this_binary);
+
+    // Pass on the arguments we received so that they can be inspected later.
+    // We're interested in flags like `--offline` and `--config` which have to be passed to `cargo metadata` later.
+    // The shell has already split them for us and we don't want to mangle them, but we need to round-trip them
+    // through a string. Since we already depend on `serde-json` and it does the job, use JSON.
+    // This doesn't support non-UTF8 paths, but `cargo_metadata` crate doesn't support them either, so...
+    let args = SerializedCargoArgs::from_args();
+    let args_in_json = serde_json::to_string(&args).unwrap();
+    command.env("CARGO_AUDITABLE_ORIG_ARGS", args_in_json);
+
     let results = command
         .status()
         .expect("Failed to invoke cargo! Make sure it's in your $PATH");

--- a/cargo-auditable/src/main.rs
+++ b/cargo-auditable/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod cargo_arguments;
 mod cargo_auditable;
 mod collect_audit_data;
 mod object_file;


### PR DESCRIPTION
Fixes #83

I have no evidence that this is even needed; I just based this off the reading of my code. 

Cargo does set 25 additional environment variables, so it may be passing this configuration on without us having to explicitly do that; this is something that needs to be double-checked.