### PR TITLE
cope with failure to parse rustc args

### DIFF
--- a/cargo-auditable/tests/it.rs
+++ b/cargo-auditable/tests/it.rs
@@ -350,3 +350,14 @@ fn test_runtime_then_build_dep() {
         .iter()
         .any(|p| p.name == "build_dep_of_runtime_dep" && p.kind == DependencyKind::Build));
 }
+
+#[test]
+fn test_workspace_member_version_info() {
+    // Test that `/path/to/cargo-auditable rustc -vV works when compiling a workspace member
+    let mut command = Command::new(EXE);
+    command.env("CARGO_PRIMARY_PACKAGE", "true");
+    command.args(["rustc", "-vV"]);
+
+    let status = command.status().unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
Don't panic if rustc args can't be parsed, instead just don't attempt to link auditable information.
This is to fix running with sccache where it may run `/path/to/cargo-auditable rustc -vV` when compiling a workspace member.

I thought it better to cope generally with a failure to parse rustc args, but I could also see the merits of special casing `-vV` so as to make regressions more detectable in future. WDYT?

I've verified locally with a project that was previously failing, and by running 
```
tom [ ~/cargo-auditable ]$ CARGO_PRIMARY_PACKAGE=foo ~/.target/debug/cargo-auditable rustc -vV
rustc 1.64.0-dev
binary: rustc
commit-hash: dd496d0
commit-date: 2022-09-24
host: x86_64-unknown-linux-gnu
release: 1.64.0-dev
LLVM version: 14.0.6
```

Fixes https://github.com/rust-secure-code/cargo-auditable/issues/87