### PR TITLE
Fix examples in docs

### DIFF
--- a/auditable-info/README.md
+++ b/auditable-info/README.md
@@ -12,9 +12,9 @@ Deserializes them to a JSON string or Rust data structures, at your option.
 
 ### Usage
 
-```rust, ignore
+```rust
 // Uses the default limits: 1GiB input file size, 8MiB audit data size
-let info = audit_info_from_file("path/to/file", Default::default())?;
+let info = audit_info_from_file(&PathBuf::from("path/to/file"), Default::default())?;
 ```
 Functions to load the data from a `Read` instance or from `&[u8]` are also provided,
 see the [documentation](https://docs.rs/auditable-info).

--- a/auditable-info/src/lib.rs
+++ b/auditable-info/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```rust, ignore
 //! // Uses the default limits: 1GiB input file size, 8MiB audit data size
-//! let info = audit_info_from_file("path/to/file", Default::default())?;
+//! let info = audit_info_from_file(&PathBuf::from("path/to/file"), Default::default())?;
 //! ```
 //! Functions to load the data from a `Read` instance or from `&[u8]` are also provided.
 //!
@@ -32,7 +32,7 @@ pub use crate::error::Error;
 ///
 /// ```rust, ignore
 /// // Uses the default limits: 1GiB input file size, 8MiB audit data size
-/// let info = audit_info_from_file("path/to/file", Default::default())?;
+/// let info = audit_info_from_file(&PathBuf::from("path/to/file"), Default::default())?;
 /// ```
 ///
 /// The data is validated to only have a single root package and not contain any circular dependencies.


### PR DESCRIPTION
`audit_info_from_file` accepts a `&Path` instead of a `&str`