### PR TITLE
Sync to latest object file writing code from rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -156,30 +156,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "idna"
@@ -239,12 +228,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "crc32fast",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
  "indexmap",
  "memchr",
 ]
@@ -444,12 +433,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-object = {version = "0.28.1", default-features = false, features = ["write"]}
+object = {version = "0.30", default-features = false, features = ["write"]}
 auditable-serde = {version = "0.5.0", path = "../auditable-serde", features = ["from_metadata"]}
 miniz_oxide = {version = "0.5.0"}
 serde_json = "1.0.57"

--- a/cargo-auditable/src/object_file.rs
+++ b/cargo-auditable/src/object_file.rs
@@ -120,7 +120,7 @@ fn create_object_file(
         }
         Architecture::Mips64 => {
             // copied from `mips64el-linux-gnuabi64-gcc foo.c -c`
-            #[allow(clippy::let_and_return)] // for keeping the code as close to upstream as possible
+            #[allow(clippy::let_and_return)] // for staying as close to upstream as possible
             let e_flags = elf::EF_MIPS_CPIC
                 | elf::EF_MIPS_PIC
                 | if target_triple.contains("r6") {

--- a/cargo-auditable/src/object_file.rs
+++ b/cargo-auditable/src/object_file.rs
@@ -117,7 +117,6 @@ fn create_object_file(
                 e_flags |= elf::EF_MIPS_NAN2008;
             }
             e_flags
-
         }
         Architecture::Mips64 => {
             // copied from `mips64el-linux-gnuabi64-gcc foo.c -c`
@@ -149,7 +148,7 @@ fn create_object_file(
             }
             e_flags
         }
-        _ => 0
+        _ => 0,
     };
     // adapted from LLVM's `MCELFObjectTargetWriter::getOSABI`
     let os_abi = match info["target_os"].as_str() {
@@ -159,7 +158,11 @@ fn create_object_file(
         _ => elf::ELFOSABI_NONE,
     };
     let abi_version = 0;
-    file.flags = FileFlags::Elf { os_abi, abi_version, e_flags };
+    file.flags = FileFlags::Elf {
+        os_abi,
+        abi_version,
+        e_flags,
+    };
     Some(file)
 }
 

--- a/cargo-auditable/src/object_file.rs
+++ b/cargo-auditable/src/object_file.rs
@@ -134,14 +134,14 @@ fn create_object_file(
             let mut e_flags: u32 = 0x0;
             let features = riscv_features(target_triple);
             // Check if compressed is enabled
-            if features.contains("c") {
+            if features.contains('c') {
                 e_flags |= elf::EF_RISCV_RVC;
             }
 
             // Select the appropriate floating-point ABI
-            if features.contains("d") {
+            if features.contains('d') {
                 e_flags |= elf::EF_RISCV_FLOAT_ABI_DOUBLE;
-            } else if features.contains("f") {
+            } else if features.contains('f') {
                 e_flags |= elf::EF_RISCV_FLOAT_ABI_SINGLE;
             } else {
                 e_flags |= elf::EF_RISCV_FLOAT_ABI_SOFT;
@@ -174,7 +174,7 @@ fn riscv_features(target_triple: &str) -> String {
     assert_eq!(&arch[..5], "riscv");
     let mut extensions = arch[7..].to_owned();
     if extensions.contains('g') {
-        extensions.push_str(&"imadf");
+        extensions.push_str("imadf");
     }
     extensions
 }

--- a/cargo-auditable/src/object_file.rs
+++ b/cargo-auditable/src/object_file.rs
@@ -120,6 +120,7 @@ fn create_object_file(
         }
         Architecture::Mips64 => {
             // copied from `mips64el-linux-gnuabi64-gcc foo.c -c`
+            #[allow(clippy::let_and_return)] // for keeping the code as close to upstream as possible
             let e_flags = elf::EF_MIPS_CPIC
                 | elf::EF_MIPS_PIC
                 | if target_triple.contains("r6") {


### PR DESCRIPTION
Also bumps `object` to 0.30, enabling Debian packaging

Fixes #103