### PR TITLE
Disable emitting audit info in presence of `--print` statements

### DIFF
--- a/auditable-serde/src/lib.rs
+++ b/auditable-serde/src/lib.rs
@@ -57,7 +57,7 @@ use cargo_lock;
 use std::convert::TryFrom;
 #[cfg(feature = "toml")]
 use std::convert::TryInto;
-use std::str::FromStr;
+use std::{str::FromStr, default};
 #[cfg(feature = "from_metadata")]
 #[cfg(feature = "from_metadata")]
 use std::{cmp::min, cmp::Ordering::*, collections::HashMap, error::Error, fmt::Display};
@@ -186,20 +186,15 @@ impl From<&cargo_metadata::Source> for Source {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum DependencyKind {
     // The values are ordered from weakest to strongest so that casting to integer would make sense
     #[serde(rename = "build")]
     Build,
+    #[default]
     #[serde(rename = "runtime")]
     Runtime,
-}
-
-impl Default for DependencyKind {
-    fn default() -> Self {
-        DependencyKind::Runtime
-    }
 }
 
 /// The values are ordered from weakest to strongest so that casting to integer would make sense

--- a/auditable-serde/src/lib.rs
+++ b/auditable-serde/src/lib.rs
@@ -57,7 +57,7 @@ use cargo_lock;
 use std::convert::TryFrom;
 #[cfg(feature = "toml")]
 use std::convert::TryInto;
-use std::{str::FromStr, default};
+use std::str::FromStr;
 #[cfg(feature = "from_metadata")]
 #[cfg(feature = "from_metadata")]
 use std::{cmp::min, cmp::Ordering::*, collections::HashMap, error::Error, fmt::Display};

--- a/cargo-auditable/src/rustc_arguments.rs
+++ b/cargo-auditable/src/rustc_arguments.rs
@@ -18,6 +18,7 @@ pub struct RustcArgs {
     pub cfg: Vec<String>,
     pub out_dir: PathBuf,
     pub target: Option<String>,
+    pub print: Vec<String>,
 }
 
 impl RustcArgs {
@@ -46,5 +47,6 @@ pub fn parse_args() -> Result<RustcArgs, pico_args::Error> {
             Ok(PathBuf::from(s))
         })?,
         target: parser.opt_value_from_str("--target")?,
+        print: parser.values_from_str("--print")?,
     })
 }

--- a/cargo-auditable/src/rustc_wrapper.rs
+++ b/cargo-auditable/src/rustc_wrapper.rs
@@ -16,9 +16,11 @@ pub fn main(rustc_path: &OsStr) {
     if env::var_os("CARGO_PRIMARY_PACKAGE").is_some() {
         let arg_parsing_result = rustc_arguments::parse_args();
         if let Ok(args) = rustc_arguments::parse_args() {
-            // Only inject audit data into crate types 'bin' and 'cdylib'
-            if args.crate_types.contains(&"bin".to_owned())
-                || args.crate_types.contains(&"cdylib".to_owned())
+            // Only inject audit data into crate types 'bin' and 'cdylib',
+            // and only if --print is not specified (which disables compilation)
+            if args.print.is_empty() &&
+             (args.crate_types.contains(&"bin".to_owned())
+                || args.crate_types.contains(&"cdylib".to_owned()))
             {
                 // Get the audit data to embed
                 let target_triple = args

--- a/cargo-auditable/src/rustc_wrapper.rs
+++ b/cargo-auditable/src/rustc_wrapper.rs
@@ -18,9 +18,9 @@ pub fn main(rustc_path: &OsStr) {
         if let Ok(args) = rustc_arguments::parse_args() {
             // Only inject audit data into crate types 'bin' and 'cdylib',
             // and only if --print is not specified (which disables compilation)
-            if args.print.is_empty() &&
-             (args.crate_types.contains(&"bin".to_owned())
-                || args.crate_types.contains(&"cdylib".to_owned()))
+            if args.print.is_empty()
+                && (args.crate_types.contains(&"bin".to_owned())
+                    || args.crate_types.contains(&"cdylib".to_owned()))
             {
                 // Get the audit data to embed
                 let target_triple = args


### PR DESCRIPTION
When these options are present rustc doesn't actually emit any code, so no need try to create any kind of audit info.