### PR TITLE
auditable-serde: bump `cargo-lock` to v9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "auditable-serde"
-version = "0.5.2"
+version = "0.6.0-pre"
 dependencies = [
  "cargo-lock",
  "cargo_metadata",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.2"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4c54d47a4532db3494ef7332c257ab57b02750daae3250d49e01ee55201ce8"
+checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
 dependencies = [
  "semver",
  "serde",
@@ -356,6 +356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,11 +392,36 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -443,4 +477,13 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
 ]

--- a/auditable-info/Cargo.toml
+++ b/auditable-info/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 auditable-extract = {version = "0.3.0", path = "../auditable-extract"}
 miniz_oxide = { version = "0.6.2", features = ["std"] }
-auditable-serde = {version = "0.5.0", path = "../auditable-serde", optional = true}
+auditable-serde = {version = "=0.6.0-pre", path = "../auditable-serde", optional = true}
 serde_json = { version = "1.0.57", optional = true }
 
 [features]

--- a/auditable-serde/Cargo.toml
+++ b/auditable-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auditable-serde"
-version = "0.5.2"
+version = "0.6.0-pre"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-secure-code/cargo-auditable"
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1.0.57"
 semver = { version = "1.0", features = ["serde"] }
 cargo_metadata = { version = "0.15", optional = true }
-cargo-lock = { version = "8.0.2", default-features = false, optional = true }
+cargo-lock = { version = "9", default-features = false, optional = true }
 topological-sort = "0.2.2"
 schemars = {version = "0.8.10", optional = true }
 

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 [dependencies]
 object = {version = "0.30", default-features = false, features = ["write"]}
-auditable-serde = {version = "0.5.0", path = "../auditable-serde", features = ["from_metadata"]}
+auditable-serde = {version = "=0.6.0-pre", path = "../auditable-serde", features = ["from_metadata"]}
 miniz_oxide = {version = "0.5.0"}
 serde_json = "1.0.57"
 cargo_metadata = "0.15"


### PR DESCRIPTION
This is a SemVer breaking change as `cargo-lock` is part of the public API by way of trait impls, so this also bumps the version of `auditable-serde` to v0.6.0-pre.