### PR TITLE
feat: support Windows targets

### DIFF
--- a/cargo-auditable/src/rustc_wrapper.rs
+++ b/cargo-auditable/src/rustc_wrapper.rs
@@ -52,7 +52,11 @@ pub fn main(rustc_path: &OsStr) {
                     // Prevent the symbol from being removed as unused by the linker
                     if target_triple.contains("-apple-") {
                         command.arg("-Clink-arg=-Wl,-u,_AUDITABLE_VERSION_INFO");
-                    } else {
+                    } else if target_triple.ends_with("-msvc") {
+                        // https://learn.microsoft.com/en-us/cpp/build/reference/include-force-symbol-references?view=msvc-170
+                        command.arg("-Clink-arg=/INCLUDE:AUDITABLE_VERSION_INFO");
+                    }
+                    else {
                         command.arg("-Clink-arg=-Wl,--undefined=AUDITABLE_VERSION_INFO");
                     }
                 } else {


### PR DESCRIPTION
Currently, I believe that everything works EXCEPT passing the Unix-style arguments to the linker.

This fixes it by passing a LINK.exe argument for the linker to keep the symbol.

(Untested for now. I will do it shortly.)