### PR TITLE
upgrade dependency miniz_oxide to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.7.0"
 dependencies = [
  "auditable-extract",
  "auditable-serde",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "serde_json",
 ]
 
@@ -77,7 +77,7 @@ dependencies = [
  "auditable-info",
  "auditable-serde",
  "cargo_metadata",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
  "object",
  "pico-args",
  "serde",
@@ -207,15 +207,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 object = {version = "0.30", default-features = false, features = ["write"]}
 auditable-serde = {version = "0.6.0", path = "../auditable-serde", features = ["from_metadata"]}
-miniz_oxide = {version = "0.5.0"}
+miniz_oxide = {version = "0.6.0"}
 serde_json = "1.0.57"
 cargo_metadata = "0.15"
 pico-args = "0.5"


### PR DESCRIPTION
As 0.6 is packaged in Debian: https://packages.debian.org/trixie/librust-miniz-oxide-dev

cargo-auditable is finally on it way into testing: https://qa.debian.org/excuses.php?package=rust-cargo-auditable

With two patches:

https://sources.debian.org/src/rust-cargo-auditable/0.6.1-1/debian/patches/disable-unsupported-arch.patch/ <-- The Aarch64_Ilp32 didn't exist for some reason that I haven't dug into yet.

https://sources.debian.org/src/rust-cargo-auditable/0.6.1-1/debian/patches/relax-deps.patch/ <-- I packaged the latest versions of auditable-serde and auditable-info, I hope this won't present a problem.