### PR TITLE
Use the correct link.exe flag for preserving the specified symbol even if it is unused

### DIFF
--- a/cargo-auditable/src/rustc_wrapper.rs
+++ b/cargo-auditable/src/rustc_wrapper.rs
@@ -52,6 +52,8 @@ pub fn main(rustc_path: &OsStr) {
                     // Prevent the symbol from being removed as unused by the linker
                     if target_triple.contains("-apple-") {
                         command.arg("-Clink-arg=-Wl,-u,_AUDITABLE_VERSION_INFO");
+                    } else if target_triple.ends_with("-msvc") {
+                        command.arg("-Clink-arg=/INCLUDE:AUDITABLE_VERSION_INFO");
                     } else {
                         command.arg("-Clink-arg=-Wl,--undefined=AUDITABLE_VERSION_INFO");
                     }


### PR DESCRIPTION
Might fix #141