### PR TITLE
Run wasm tests if wasm feature is enabled

### DIFF
--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -26,3 +26,6 @@ wasm-gen = "0.1.4"
 cargo_metadata = "0.15"
 auditable-info = {version = "0.7.1", path = "../auditable-info", features = ["wasm"]}
 which = "4.3.0"
+
+[features]
+wasm = []

--- a/cargo-auditable/tests/it.rs
+++ b/cargo-auditable/tests/it.rs
@@ -426,6 +426,7 @@ fn test_workspace_member_version_info() {
 }
 
 #[test]
+#[cfg(feature = "wasm")]
 fn test_wasm() {
     // Path to workspace fixture Cargo.toml. See that file for overview of workspace members and their dependencies.
     let workspace_cargo_toml =


### PR DESCRIPTION
Hey, Arch packager of `cargo-auditable` here! :wave:

I was updating the package to 0.6.3 and realized the wasm tests are being run regardless of `wasm` feature is enabled or not.

This PR simply disables `test_wasm` if `wasm` feature is not enabled.

Let me know if this is a change that you want to make / if this needs any additional changes!

Cheers.
