### PR TITLE
Upgrade wasmparser to remove dependencies with `unsafe`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,11 @@ jobs:
           toolchain: stable
           override: true
       - name: Run cargo check
-        run: cargo check --locked
+        run: cargo check --workspace --locked
+      - name: Run cargo check --no-default-features
+        run: cargo check --workspace --locked --no-default-features
+      - name: Run cargo check --all-features
+        run: cargo check --workspace --locked --all-features
       - name: Run cargo clippy
         run: cargo clippy -- -D warnings
       - name: Check format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "auditable-extract"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "binfarce",
  "wasmparser",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "auditable-info"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "auditable-extract",
  "auditable-serde",
@@ -284,9 +284,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "idna"
@@ -767,15 +764,11 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39192edb55d55b41963db40fd49b0b542156f04447b5b512744a91d38567bdbc"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
 dependencies = [
- "ahash",
  "bitflags 2.5.0",
- "hashbrown 0.14.3",
- "indexmap 2.2.3",
- "semver",
 ]
 
 [[package]]

--- a/auditable-extract/CHANGELOG.md
+++ b/auditable-extract/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.4] - 2024-05-08
+
+### Changed
+
+ - Upgraded to `wasmparser` 0.207.0, removing nearly all dependencies with `unsafe` code in them
+ - Enabled the `wasm` feature by default now that it doesn't pull in `unsafe` code
+
+## [0.3.3] - 2024-05-03
+
+### Added
+
+ - WebAssembly support, gated behind the non-default `wasm` feature
+ - This changelog file

--- a/auditable-extract/CHANGELOG.md
+++ b/auditable-extract/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Upgraded to `wasmparser` 0.207.0, removing nearly all dependencies with `unsafe` code in them
  - Enabled the `wasm` feature by default now that it doesn't pull in `unsafe` code
+ - This changelog file
 
 ## [0.3.3] - 2024-05-03
 
 ### Added
 
  - WebAssembly support, gated behind the non-default `wasm` feature
- - This changelog file

--- a/auditable-extract/Cargo.toml
+++ b/auditable-extract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auditable-extract"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-secure-code/cargo-auditable"
@@ -12,7 +12,8 @@ edition = "2018"
 
 [dependencies]
 binfarce = "0.2"
-wasmparser = { version = "0.206.0", optional = true }
+wasmparser = { version = "0.207.0", default-features = false, optional = true }
 
 [features]
+default = ["wasm"]
 wasm = ["wasmparser"]

--- a/auditable-extract/README.md
+++ b/auditable-extract/README.md
@@ -40,16 +40,3 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 ```
-
-## WebAssembly support
-
-We use a third-party crate [`wasmparser`](https://crates.io/crates/wasmparser)
-created by Bytecode Alliance for parsing WebAssembly.
-It is a robust and high-quality parser, but its dependencies contain some `unsafe` code,
-most of which is not actually used in our build configuration.
-
-We have manually audited it and found it to be sound.
-Still, the security guarantees for it are not as ironclad as for other parsers.
-Because of that WebAssembly support is gated behind the optional `wasm` feature.
-Be sure to [enable](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features)
-the `wasm` feature if you want to parse WebAssembly.

--- a/auditable-info/CHANGELOG.md
+++ b/auditable-info/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2024-05-08
+
+### Changed
+
+ - Upgraded to `auditable-extract` v0.3.4, removing nearly all dependencies with `unsafe` code in them pulled in by `wasm` feature
+ - Enabled the `wasm` feature by default now that it doesn't pull in `unsafe` code
+
 ## [0.7.1] - 2024-05-03
 
 ### Added

--- a/auditable-info/Cargo.toml
+++ b/auditable-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auditable-info"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-secure-code/cargo-auditable"
@@ -11,12 +11,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-auditable-extract = {version = "0.3.3", path = "../auditable-extract"}
+auditable-extract = {version = "0.3.4", path = "../auditable-extract", default-features = false }
 miniz_oxide = { version = "0.6.2", features = ["std"] }
 auditable-serde = {version = "0.6.0", path = "../auditable-serde", optional = true}
 serde_json = { version = "1.0.57", optional = true }
 
 [features]
+default = ["serde", "wasm"]
 serde = ["serde_json", "auditable-serde"]
-default = ["serde"]
 wasm = ["auditable-extract/wasm"]

--- a/auditable-info/README.md
+++ b/auditable-info/README.md
@@ -23,6 +23,6 @@ see the [documentation](https://docs.rs/auditable-info).
 
 [`rust-audit-info`](https://crates.io/crates/rust-audit-info) is a command-line interface to this crate.
 
-If you need an even lower-level interface than the one provided by this crate,
+If you need a lower-level interface than the one provided by this crate,
 use the [`auditable-extract`](http://docs.rs/auditable-extract/) and
 [`auditable-serde`](http://docs.rs/auditable-serde/) crates.

--- a/rust-audit-info/Cargo.toml
+++ b/rust-audit-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-audit-info"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-secure-code/cargo-auditable"
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-auditable-info = {version = "0.7.1", default-features = false, path = "../auditable-info"}
+auditable-info = {version = "0.7.2", default-features = false, path = "../auditable-info"}
 
 [features]
 wasm = ["auditable-info/wasm"]


### PR DESCRIPTION
Also enables the `wasm` feature by default.