### PR TITLE
Add openSUSE to adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo audit bin target/release/your-project
 
 Microsoft uses `cargo auditable` internally and maintains the [data extraction library for Go](https://github.com/microsoft/go-rustaudit).
 
-Multiple Linux distributions build their Rust packages with `cargo auditable`: [Alpine Linux](https://www.alpinelinux.org/), [NixOS](https://nixos.org/), [Void Linux](https://voidlinux.org/) and [Chimera Linux](https://chimera-linux.org/). If you install packages from their repositories, you can audit them!
+Multiple Linux distributions build their Rust packages with `cargo auditable`: [Alpine Linux](https://www.alpinelinux.org/), [NixOS](https://nixos.org/), [openSUSE](https://www.opensuse.org/), [Void Linux](https://voidlinux.org/) and [Chimera Linux](https://chimera-linux.org/). If you install packages from their repositories, you can audit them!
 
 ## FAQ
 


### PR DESCRIPTION
https://github.com/openSUSE-Rust/cargo-packaging uses `cargo auditable`

With just 5 github stars I thought it's not used in production, but I downloaded the openSUSE Tumbleweed live image and it has Rust binaries in its repos built with `cargo auditable`