### PR TITLE
Fix auditable data extraction for wasm component 

### DIFF
--- a/auditable-extract/src/wasm.rs
+++ b/auditable-extract/src/wasm.rs
@@ -2,36 +2,11 @@
 
 use crate::Error;
 
-use wasmparser::{self, Chunk, Payload};
+use wasmparser::{self, Payload};
 
-pub(crate) fn raw_auditable_data_wasm(mut input: &[u8]) -> Result<&[u8], Error> {
-    let mut parser = wasmparser::Parser::new(0);
-
-    // `wasmparser` relies on manually advancing the offset,
-    // which potentially allows infinite loops if the logic is wrong somewhere.
-    // Therefore, limit the maximum number of iterations to 10,000.
-    // This is way more than any sane WASM blob will have,
-    // and prevents infinite loops in case of such logic errors.
-    for _i in 0..10_000 {
-        // wasmparser errors are strings, so we can't reasonably convert them
-        let payload = match parser
-            .parse(input, true)
-            .map_err(|_| Error::MalformedFile)?
-        {
-            // This shouldn't be possible because `eof` is always true.
-            Chunk::NeedMoreData(_) => return Err(Error::MalformedFile),
-
-            Chunk::Parsed { payload, consumed } => {
-                // Guard against made-up "consumed" values that would cause a panic
-                input = match input.get(consumed..) {
-                    Some(input) => input,
-                    None => return Err(Error::MalformedFile),
-                };
-                payload
-            }
-        };
-
-        match payload {
+pub(crate) fn raw_auditable_data_wasm(input: &[u8]) -> Result<&[u8], Error> {
+    for payload in wasmparser::Parser::new(0).parse_all(input) {
+        match payload.map_err(|_| Error::MalformedFile)? {
             Payload::CustomSection(reader) => {
                 if reader.name() == ".dep-v0" {
                     return Ok(reader.data());
@@ -43,10 +18,5 @@ pub(crate) fn raw_auditable_data_wasm(mut input: &[u8]) -> Result<&[u8], Error> 
             _ => {}
         }
     }
-
-    if cfg!(debug_assertions) {
-        panic!("The parser has been running for more than 10k sections! Is it stuck?");
-    } else {
-        Err(Error::MalformedFile)
-    }
+    Err(Error::MalformedFile)
 }


### PR DESCRIPTION
See rustsec/rustsec#1255
Reworked the way auditable data is extracted from wasm modules to enable extraction from wasm components.