### PR TITLE
Upgrade and insulate miniz oxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -310,11 +310,11 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]

--- a/auditable-info/Cargo.toml
+++ b/auditable-info/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 auditable-extract = {version = "0.3.4", path = "../auditable-extract", default-features = false }
-miniz_oxide = { version = "0.6.2", features = ["std"] }
+miniz_oxide = { version = "0.8.0", features = ["std"] }
 auditable-serde = {version = "0.7.0", path = "../auditable-serde", optional = true}
 serde_json = { version = "1.0.57", optional = true }
 

--- a/auditable-info/src/lib.rs
+++ b/auditable-info/src/lib.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 
 mod error;
 
-pub use crate::error::Error;
+pub use crate::error::*;
 
 /// Loads audit info from the specified binary compiled with `cargo auditable`.
 ///
@@ -82,7 +82,8 @@ pub fn audit_info_from_reader<T: BufRead>(
 pub fn json_from_reader<T: BufRead>(reader: &mut T, limits: Limits) -> Result<String, Error> {
     let compressed_data = get_compressed_audit_data(reader, limits)?;
     let decompressed_data =
-        decompress_to_vec_zlib_with_limit(&compressed_data, limits.decompressed_json_size)?;
+        decompress_to_vec_zlib_with_limit(&compressed_data, limits.decompressed_json_size)
+            .map_err(|e| DecompressError::from_miniz(e))?;
     Ok(String::from_utf8(decompressed_data)?)
 }
 
@@ -144,7 +145,8 @@ pub fn json_from_slice(
         Err(Error::OutputLimitExceeded)?;
     }
     let decompressed_data =
-        decompress_to_vec_zlib_with_limit(compressed_audit_data, decompressed_json_size_limit)?;
+        decompress_to_vec_zlib_with_limit(compressed_audit_data, decompressed_json_size_limit)
+            .map_err(|e| DecompressError::from_miniz(e))?;
     Ok(String::from_utf8(decompressed_data)?)
 }
 

--- a/auditable-info/src/lib.rs
+++ b/auditable-info/src/lib.rs
@@ -83,7 +83,7 @@ pub fn json_from_reader<T: BufRead>(reader: &mut T, limits: Limits) -> Result<St
     let compressed_data = get_compressed_audit_data(reader, limits)?;
     let decompressed_data =
         decompress_to_vec_zlib_with_limit(&compressed_data, limits.decompressed_json_size)
-            .map_err(|e| DecompressError::from_miniz(e))?;
+            .map_err(DecompressError::from_miniz)?;
     Ok(String::from_utf8(decompressed_data)?)
 }
 
@@ -146,7 +146,7 @@ pub fn json_from_slice(
     }
     let decompressed_data =
         decompress_to_vec_zlib_with_limit(compressed_audit_data, decompressed_json_size_limit)
-            .map_err(|e| DecompressError::from_miniz(e))?;
+            .map_err(DecompressError::from_miniz)?;
     Ok(String::from_utf8(decompressed_data)?)
 }
 

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 object = {version = "0.30", default-features = false, features = ["write"]}
 auditable-serde = {version = "0.7.0", path = "../auditable-serde", features = ["from_metadata"]}
-miniz_oxide = {version = "0.6.0"}
+miniz_oxide = {version = "0.8.0"}
 serde_json = "1.0.57"
 cargo_metadata = "0.18"
 pico-args = "0.5"

--- a/rust-audit-info/Cargo.lock
+++ b/rust-audit-info/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "auditable-extract"
@@ -38,11 +38,11 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]


### PR DESCRIPTION
Remove miniz_oxide types from the public API so that we could upgrade `miniz_oxide` in the future without breaking our semver.

Also upgrades miniz_oxide to 0.8.x, superseding #168