### PR TITLE
Add test for stripped binary

### DIFF
--- a/cargo-auditable/tests/fixtures/lto_stripped_binary/Cargo.toml
+++ b/cargo-auditable/tests/fixtures/lto_stripped_binary/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lto_stripped_binary"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[workspace]
+
+[profile.release]
+lto=true
+strip=true

--- a/cargo-auditable/tests/fixtures/lto_stripped_binary/src/main.rs
+++ b/cargo-auditable/tests/fixtures/lto_stripped_binary/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/cargo-auditable/tests/it.rs
+++ b/cargo-auditable/tests/it.rs
@@ -270,6 +270,26 @@ fn test_lto() {
 }
 
 #[test]
+fn test_lto_stripped() {
+    // Path to workspace fixture Cargo.toml. See that file for overview of workspace members and their dependencies.
+    let workspace_cargo_toml = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/lto_stripped_binary/Cargo.toml");
+    // Run in workspace root with default features
+    let bins = run_cargo_auditable(workspace_cargo_toml, &[], &[]);
+    eprintln!("Stripped binary map: {bins:?}");
+
+    // lto_stripped_binary should only depend on itself
+    let lto_stripped_binary_bin = &bins.get("lto_stripped_binary").unwrap()[0];
+    let dep_info = get_dependency_info(lto_stripped_binary_bin);
+    eprintln!("{lto_stripped_binary_bin} dependency info: {dep_info:?}");
+    assert!(dep_info.packages.len() == 1);
+    assert!(dep_info
+        .packages
+        .iter()
+        .any(|p| p.name == "lto_stripped_binary"));
+}
+
+#[test]
 fn test_bin_and_lib_in_one_crate() {
     // Path to workspace fixture Cargo.toml. See that file for overview of workspace members and their dependencies.
     let workspace_cargo_toml = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Ensures that stripping all debug info and everything else the linker deems unnecessary still preserves the section we injected