### PR TITLE
Add Wolfi OS and Chainguard to adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ If you're not calling `cargo` directly and cannot change how it's invoked, you c
 
 Microsoft uses `cargo auditable` internally and maintains the [data extraction library for Go](https://github.com/microsoft/go-rustaudit).
 
-Multiple Linux distributions build their Rust packages with `cargo auditable`: [Alpine Linux](https://www.alpinelinux.org/), [NixOS](https://nixos.org/), [openSUSE](https://www.opensuse.org/), [Void Linux](https://voidlinux.org/) and [Chimera Linux](https://chimera-linux.org/). If you install packages from their repositories, you can audit them!
+[Chainguard](https://chainguard.dev/) includes `cargo auditable` in their [rust base container](https://images.chainguard.dev/directory/image/rust/overview), with a default `cargo` wrapper to always call `cargo auditable`, so that Rust applications built using this container are auditable by default.
+
+Multiple Linux distributions build their Rust packages with `cargo auditable`: [Alpine Linux](https://www.alpinelinux.org/), [NixOS](https://nixos.org/), [openSUSE](https://www.opensuse.org/), [Void Linux](https://voidlinux.org/), [Chimera Linux](https://chimera-linux.org/) and [Wolfi OS](https://wolfi.dev). If you install packages from their repositories, you can audit them!
 
 ## FAQ
 


### PR DESCRIPTION
I found a reference in https://github.com/luser/rustfilt/issues/23 that Wolfi is using cargo-auditable, and looking through their repos, it seems they do that by default. @xnox, is it okay to mention Wolfi as an adopter here?
