### PR TITLE
Minor Clippy fix

### DIFF
--- a/cargo-auditable/tests/it.rs
+++ b/cargo-auditable/tests/it.rs
@@ -175,7 +175,7 @@ fn test_cargo_auditable_workspaces_inner(sbom: bool) {
     let bins = run_cargo_auditable(&workspace_cargo_toml, &[], &[], sbom);
     eprintln!("Test fixture binary map: {bins:?}");
     // No binaries for library_crate
-    assert!(bins.get("library_crate").is_none());
+    assert!(!bins.contains_key("library_crate"));
 
     // binary_and_cdylib_crate
     let binary_and_cdylib_crate_bins = bins.get("binary_and_cdylib_crate").unwrap();


### PR DESCRIPTION
As I didn't get any reply in the [discussion](https://github.com/rust-secure-code/cargo-auditable/discussions/219), and I see Clippy fixes in the git log, I decided to simply go ahead and submit this one.

Fixes this;
```rust
warning: unnecessary use of `get("library_crate").is_none()`
   --> cargo-auditable/tests/it.rs:178:18
    |
178 |     assert!(bins.get("library_crate").is_none());
    |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |             |
    |             help: replace it with: `!bins.contains_key("library_crate")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check
```


BTW, the `test_wasm` test fails on `master`. I haven't looked any deeper into why, but also don't see any open issues for that. Is the failure expected? Would it be helpful if I looked into that?