### PR TITLE
Enable `aarch64-unknown-linux-musl` build target in `cargo-dist`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-auditable"
-version = "0.7.4"
+version = "0.7.5-test.1"
 edition = "2021"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-auditable"
-version = "0.7.5-test.1"
+version = "0.7.4"
 edition = "2021"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It turns out that `cargo-dist` does support the `aarch64-unknown-linux-musl` target it just has to be enabled.  In the `workspace.metadata.dist` section in `Cargo.toml` I just added `aarch64-unknown-linux-musl`:

```toml
targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
```

In my fork I then made a new "release" tag and confirmed that it built and published to artifacts the aarch64 musl bits.

You can see the `Release` workflow built on my fork [here](https://github.com/anelson/cargo-auditable/actions/runs/23241554119).  The specific `aarch64-unknown-linux-musl` build is [here](https://github.com/anelson/cargo-auditable/actions/runs/23241554119/job/67559064717).

Closes #249 
