### PR TITLE
Run CI checks on 1.88 to prevent accidental MSRV drift

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.88.0
+          components: rustfmt, clippy
           override: true
       - name: Run cargo check
         run: cargo check --workspace --locked


### PR DESCRIPTION
cargo-auditable builds on 1.86 but workspace MSRV is 1.88 to get the latest patched `time` so that vulnerability scanners wouldn't scream at people