### PR TITLE
add example for rustup `+toolchain` syntax when replacing cargo

### DIFF
--- a/REPLACING_CARGO.md
+++ b/REPLACING_CARGO.md
@@ -23,3 +23,12 @@ When calling other programs such as `cmake` or `maturin`, the shell alias usuall
 REAL_CARGO='/path/to/real/cargo' # replace this with your path
 exec "$REAL_CARGO" auditable "$@"
 ```
+
+If you want to preserve rustup's `+toolchain` syntax, shift it before the `auditable` subcommand:
+
+```bash
+case "$1" in
+  +*) toolchain="$1"; shift; exec "$REAL_CARGO" "$toolchain" auditable "$@" ;;
+   *)                        exec "$REAL_CARGO"              auditable "$@" ;;
+esac
+```


### PR DESCRIPTION
The given example script means `cargo +toolchain build` turns into `$CARGO auditable +toolchain build`, and rustup only inspects the first argument for `+toolchain` syntax, so the example wrapper precludes using `+toolchain` syntax. The alternate wrapper that I've added an example for recognizes the `+toolchain` argument to exec `$CARGO +toolchain auditable build` instead, allowing the `+toolchain` instruction to be processed by rustup.