### PR TITLE
Upgrade miniz_oxide to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "auditable-info"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "auditable-extract",
  "auditable-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,11 +346,12 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
+ "serde",
 ]
 
 [[package]]

--- a/auditable-info/Cargo.toml
+++ b/auditable-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auditable-info"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-secure-code/cargo-auditable"

--- a/auditable-info/Cargo.toml
+++ b/auditable-info/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 auditable-extract = {version = "0.3.4", path = "../auditable-extract", default-features = false }
-miniz_oxide = { version = "0.8.0", features = ["std"] }
+miniz_oxide = { version = "0.9", features = ["std"] }
 auditable-serde = {version = "0.9.0", path = "../auditable-serde", optional = true}
 serde_json = { version = "1.0.57", optional = true }
 

--- a/auditable-info/src/error.rs
+++ b/auditable-info/src/error.rs
@@ -140,6 +140,7 @@ impl TINFLStatus {
             inflate::TINFLStatus::Done => Self::Done,
             inflate::TINFLStatus::NeedsMoreInput => Self::NeedsMoreInput,
             inflate::TINFLStatus::HasMoreOutput => Self::HasMoreOutput,
+            _ => Self::Failed, // Unknown status
         }
     }
 }

--- a/cargo-auditable/Cargo.toml
+++ b/cargo-auditable/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 object = {version = "0.37", default-features = false, features = ["write"]}
 auditable-serde = {version = "0.9.0", path = "../auditable-serde"}
-miniz_oxide = {version = "0.8.0"}
+miniz_oxide = {version = "0.9"}
 serde_json = "1.0.57"
 cargo_metadata = "0.23"
 pico-args = { version = "0.5", features = ["eq-separator", "short-space-opt"] }


### PR DESCRIPTION
To avoid downstream duplicate dependencies (noticed in the rustsec crate).

Alternatively, could port these to zlib-rs?